### PR TITLE
Corrige création des Review Apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,9 @@
   },
   "env": {
     "RACK_ENV": "production",
-    "RAILS_ENV": "production"
+    "RAILS_ENV": "production",
+    "SENTRY_PRIVATE_DSN": "asdf1234",
+    "SENTRY_PUBLIC_DSN": "asdf1234"
   },
   "buildpacks": [{
     "url": "https://github.com/tempoautomation/heroku-buildpack-sourceversion.git"


### PR DESCRIPTION
Après l'installation de raven (sentry), la création des review apps ne
marche plus dû au manque des variables d'environment définissant les DSN
public et privé.