### PR TITLE
Problème d'affichage (les feuilles de style ne sont pas prises en compte)

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
     %meta{ name: 'sentry-dsn', content: ENV['SENTRY_PUBLIC_DSN'] }
     %base{ href: root_path }
     = yield(:twitter_card)
-    = stylesheet_link_tag :application, media: :all, integrity: true
+    = stylesheet_link_tag :application, media: :all
     = csrf_meta_tags
   %body
     %header{ role: 'banner' }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,7 +96,7 @@ Rails.application.configure do
   }
 
   # Force SSL
-  config.force_ssl = false
+  config.force_ssl = true
 
   # Analytics
   MetaEvents::Tracker.default_event_receivers << Mixpanel::Tracker.new(ENV['MIXPANEL_TOKEN']) if ENV['MIXPANEL_TOKEN']


### PR DESCRIPTION
Le problème est dû au « SRI ».

SRI (Subresource Integrity) est une technologie qui améliore la sécurité du site, en ajoutant un  jeton unique aux fichiers CSS (feuilles de style) et JS (javascript).

Malheureusement, certains navigateurs ne sont pas encore 100% compatibles avec cette technologie (dont votre version de Firefox).

https://bugzilla.mozilla.org/show_bug.cgi?id=1269241