### PR TITLE
adding button target public on the index page of service offerings

### DIFF
--- a/app/views/agents/service_offerings/index.html.haml
+++ b/app/views/agents/service_offerings/index.html.haml
@@ -26,4 +26,23 @@
                 %td= service_offering.title
                 %td= service_offering.public_service_title
                 %td= service_offering.social_right_name
+
                 = render(partial: 'blocks/button_groups/agents_index', locals: { model: service_offering })
+
+                %td
+                  - if feature?(:define_target_public)
+
+                  - target_public = TargetPublicDecorator.(service_offering.target_public)
+
+                    - if policy(target_public).define?
+                      = link_to t('.target_public.show'),
+                                agents_service_offering_target_public_path(service_offering),
+                                class: 'button-info',
+                                role: 'link'
+
+                    - else
+                      .profile-form-no-action
+
+
+
+

--- a/app/views/agents/service_offerings/target_publics/show.html.haml
+++ b/app/views/agents/service_offerings/target_publics/show.html.haml
@@ -13,3 +13,9 @@
       %hr
 
       = render(partial: 'form', locals: { service_offering: @service_offering, target_public: @target_public })
+
+    .profile-form-actions
+      = link_to t('.index'),
+                agents_service_offerings_path(@service_offerings),
+                class: 'button-default',
+                role: 'link'

--- a/app/views/blocks/button_groups/_agents_index.html.haml
+++ b/app/views/blocks/button_groups/_agents_index.html.haml
@@ -19,3 +19,5 @@
             method: :delete,
             role: 'link',
             data: { confirm: t('blocks.button_groups.confirm') }
+
+

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -192,6 +192,8 @@ fr:
       index:
         heading: 'Liste des offres de service à %{rhizome}'
         new: Ajouter une nouvelle offre de service
+        target_public:
+          show: Public cible
       show:
         target_public:
           show: Public cible

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -203,6 +203,8 @@ fr:
       edit:
         heading: Mettre à jour l'offre de service
       target_publics:
+        show:
+          index: Retour à la liste des offres de service
         form:
           criterium: Critère
           target_public: Public cible

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170418163431) do
+ActiveRecord::Schema.define(version: 20170418163816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,17 @@ ActiveRecord::Schema.define(version: 20170418163431) do
   end
 
   add_index "engagements", ["name"], name: "index_engagements_on_name", unique: true, using: :btree
+
+  create_table "engagements_target_publics", id: false, force: :cascade do |t|
+    t.integer  "target_public_id", null: false
+    t.integer  "engagement_id",    null: false
+    t.integer  "engagements_id",   null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
+
+  add_index "engagements_target_publics", ["engagements_id"], name: "index_engagements_target_publics_on_engagements_id", using: :btree
+  add_index "engagements_target_publics", ["target_public_id"], name: "index_engagements_target_publics_on_target_public_id", using: :btree
 
   create_table "exercise_scopes", force: :cascade do |t|
     t.integer  "social_right_id",  null: false


### PR DESCRIPTION
1) Added buttons on the index page of service offerings to go directly to the target public of each service offering (without using the show page).

2) Added a button on the show page of the target public to go back directly to the list of service offerings (service offerings index page).
